### PR TITLE
add mimicry module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Current modules (not all are documented yet):
 - **Velocity**
 - **Chatlogger**
 - **Confighandler**
+- **Mimicry**
 
 All features are toggleable and execute actions on every `physicsTick`.
 
@@ -80,6 +81,19 @@ Automatically eats when the bot’s hunger drops below 18.
 - Prioritizes high-quality food (`cooked_meat` types).
 - If no good food is found, falls back to any other edible items.
 
+---
+
+### Mimicry (`bot.mimicry(action)`)
+
+Makes the bot mimic the behavior of the nearest player.
+
+**Arguments:**
+- `action` – `"on"` to activate, `"off"` to deactivate
+
+**Behavior:**
+- Continuously looks at the nearest player.
+- Mimics their sneaking status.
+- If the player swings their arm (i.e., punches) while at least 5 blocks away, the bot responds by swinging three times in return.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -322,6 +322,86 @@ function chatlogger(bot, action) {
   }
 }
 
+//mimicry -v0e
+let mimicEnabled = false;
+let mimicInterval = null;
+
+function mimicry(bot, action) {
+  registerModuleCall('mimicry', action);
+
+  function isSneaking(entity) {
+    if (!entity || !entity.metadata) return false;
+    const flags = entity.metadata[0];
+    return (flags & 0x02) !== 0;
+  }
+
+  if (action === 'on') {
+    if (mimicEnabled) return;
+    mimicEnabled = true;
+
+    mimicInterval = setInterval(() => {
+      const players = Object.values(bot.entities).filter(entity =>
+        entity.type === 'player' && entity.username !== bot.username
+      );
+      if (players.length === 0) return;
+
+      let nearest = null;
+      let minDistance = Infinity;
+
+      for (const player of players) {
+        if (!player?.position) continue;
+        const dist = bot.entity.position.distanceTo(player.position);
+        if (dist < minDistance) {
+          nearest = player;
+          minDistance = dist;
+        }
+      }
+
+      if (!nearest || !nearest.position) return;
+
+      // Look at player
+      bot.lookAt(nearest.position.offset(0, 1.6, 0), true);
+
+      // Sneak mimic
+      bot.setControlState("sneak", isSneaking(nearest));
+    }, 50); // ~20 times per second
+
+    // Swing mimic
+    bot._mimicSwingHandler = (entity) => {
+      if (!mimicEnabled) return;
+      if (entity.type !== 'player' || entity.username === bot.username) return;
+
+      const dist = bot.entity.position.distanceTo(entity.position);
+      if (dist >= 5) {
+        bot.lookAt(entity.position.offset(0, 1.6, 0), true);
+        bot.swingArm('right');
+        setTimeout(() => bot.swingArm('right'), 150);
+        setTimeout(() => bot.swingArm('right'), 300);
+      }
+    };
+
+    bot.on('entitySwingArm', bot._mimicSwingHandler);
+
+  } else if (action === 'off') {
+    mimicEnabled = false;
+
+    if (mimicInterval) {
+      clearInterval(mimicInterval);
+      mimicInterval = null;
+    }
+
+    bot.setControlState('sneak', false);
+
+    if (bot._mimicSwingHandler) {
+      bot.removeListener('entitySwingArm', bot._mimicSwingHandler);
+      delete bot._mimicSwingHandler;
+    }
+  }
+}
+
+
+
+
 //config
 const configPath = 'pluginconfig.json'
 let config = {}
@@ -370,6 +450,7 @@ function plugin(bot) {
     bot.greeter = (action, mode) => greeter(bot, action, mode);
     bot.velocity = (action) => velocity(bot, action);
     bot.chatlogger = (action) => chatlogger(bot, action);
+    bot.mimicry = (action) => mimicry(bot, action);
     bot.confighandler = (action) => confighandler(bot, action);
 }
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  },
+  "dependencies": {
+    "date-fns": "^4.1.0"
+    }
 }


### PR DESCRIPTION
This PR adds a new optional module called mimicry. When enabled, the bot will:

    Rotate to look at the nearest player.

    Sneak if the player is sneaking.

    Swing its arm in response to nearby players swinging (if 5+ blocks away).

Useful for creating fun, NPC-like bots that mirror player actions.